### PR TITLE
Workaround for location parsing bug

### DIFF
--- a/lib/src/bloc.dart
+++ b/lib/src/bloc.dart
@@ -92,10 +92,16 @@ extension BlocExtension on OpenMapBloc {
     var response = await http.get(url);
     var parsed = jsonDecode(response.body);
     if (parsed is List) {
-      return parsed.map((loc) {
-        var res = FormattedLocation.from(loc);
-        return res;
-      }).toList();
+      List<FormattedLocation> resList = [];
+      for (var loc in parsed) {
+        try {
+          var res = FormattedLocation.from(loc);
+          resList.add(res);
+        } catch (e) {
+          print(e);
+        }
+      }
+      return Future<List<FormattedLocation>>.value(resList);
     } else {
       throw Exception(parsed);
     }


### PR DESCRIPTION
related to https://github.com/mo-ah-dawood/open_location_picker/issues/10

Sometimes the API returns json objects which crash the FormattedLocation.from method.
This leads to an exception and no results being shown.
This workaround does NOT yet resolve the bug, but makes it at least a lot less severe since all other search results will still be shown.